### PR TITLE
Add correct french double quote based on babel

### DIFF
--- a/smartquotes.py
+++ b/smartquotes.py
@@ -69,8 +69,8 @@ quotes = {
     },
     "french-babel": {
         "single": {
-            "start": "\u2039",
-            "end": "\u203A"
+            "start": "'",
+            "end": "'"
         },
         "double": {
             "start": "\\og ",

--- a/smartquotes.py
+++ b/smartquotes.py
@@ -67,6 +67,16 @@ quotes = {
             "end": "\\frqq"
         }
     },
+    "french-babel": {
+        "single": {
+            "start": "\u2039",
+            "end": "\u203A"
+        },
+        "double": {
+            "start": "\\og ",
+            "end": " \\fg{}"
+        }
+    }
     "french-ucs": {
         "single": {
             "start": "\u2039",


### PR DESCRIPTION
The proper way to make french "guillemets" in latex is :
`\og word \fg{}` which creates the proper `«` and `»` symbol.