### PR TITLE
Added english-gb

### DIFF
--- a/smartquotes.py
+++ b/smartquotes.py
@@ -26,6 +26,26 @@ quotes = {
             "end": "\u201D"
         }
     },
+    "english-gb": {
+        "single": {
+            "start": "``",
+            "end": "''"
+        },
+        "double": {
+            "start": "`",
+            "end": "'"
+        }
+    },
+    "english-gb-ucs": {
+        "single": {
+            "start": "\u201C",
+            "end": "\u201D"
+        },
+        "double": {
+            "start": "\u2018",
+            "end": "\u2019"
+        }
+    },
     "german": {
         "single": {
             "start": "\glq ",


### PR DESCRIPTION
Hi there,

In British English typography, single quotes are usually used on the outer quote, and double quotes inside them:
https://en.wikipedia.org/wiki/Quotation_marks_in_English#Primary_quotations_versus_secondary_quotations

This pull request adds `english-gb` and `english-gb-ucs` element to the `quotes` array which are simple versions of `english` and `english-ucs` with "single" and "double"...

Incidentally this shows that the name of those keys in the code should probably properly be described as "primary" and "secondary", rather than "single" and "double", but that is immaterial really.

Thanks for the helpful plugin!
Regards,
Mark.